### PR TITLE
Bump mstruebing/editorconfig-checker from 2.3.1 to 2.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #########################################
 FROM cljkondo/clj-kondo:2021.01.20-alpine as clj-kondo
 FROM dotenvlinter/dotenv-linter:3.0.0 as dotenv-linter
-FROM mstruebing/editorconfig-checker:2.3.1 as editorconfig-checker
+FROM mstruebing/editorconfig-checker:2.3.3 as editorconfig-checker
 FROM yoheimuta/protolint:v0.28.0 as protolint
 FROM golangci/golangci-lint:v1.36.0 as golangci-lint
 FROM koalaman/shellcheck:v0.7.1 as shellcheck


### PR DESCRIPTION
#2  mstruebing/editorconfig-checker from 2.3.1 to 2.3.3.

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
